### PR TITLE
main: set dependabot schedules to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: America/Los_Angeles
     open-pull-requests-limit: 10
@@ -12,8 +11,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: America/Los_Angeles
     open-pull-requests-limit: 5

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func (s *static) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // Render a template, or a server error.
-func render(w http.ResponseWriter, r *http.Request, tpl *template.Template, name string, data interface{}) {
+func render(w http.ResponseWriter, r *http.Request, tpl *template.Template, name string, data any) {
 	buf := new(bytes.Buffer)
 	if err := tpl.ExecuteTemplate(buf, name, data); err != nil {
 		rest.ServerError(w, r, err)


### PR DESCRIPTION
Update the existing Dependabot configuration to check Go modules and
GitHub Actions daily instead of weekly.

The repository already had the right ecosystems configured for its Go
code and CI workflow, so no additional package managers were added.

Running the required Go maintenance commands also applied a small  cleanup in main.go, replacing interface{} with any.

